### PR TITLE
Update Scaffolding

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,1 @@
+extends: .github

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,30 +1,22 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
-extends: cloudposse-github-actions/.github
-
 repository:
   # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
 
   # The name of the repository. Changing this will rename the repository
   name: test
-
   # A short description of the repository that will show up on GitHub
-  description: 🏗️ Used as a sandbox for testing. Do not use.
-
+  description: "\U0001F3D7️ Used as a sandbox for testing. Do not use."
   # A URL with more information about the repository
   homepage: https://cloudposse.com
-
   # A comma-separated list of topics to set on the repository
   topics: test, sandbox
-
   # Either `true` to enable issues for this repository, `false` to disable them.
   has_issues: false
-
   # Either `true` to enable projects for this repository, or `false` to disable them.
   # If projects are disabled for the organization, passing `true` will cause an API error.
   has_projects: false
-
   # Either `true` to enable the wiki for this repository, `false` to disable it.
   has_wiki: false
-
   # Either `true` to enable downloads for this repository, `false` to disable them.
   has_downloads: false
+_extends: .github

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,4 +1,5 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
+_extends: .github
 repository:
   # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
 
@@ -19,4 +20,3 @@ repository:
   has_wiki: false
   # Either `true` to enable downloads for this repository, `false` to disable them.
   has_downloads: false
-_extends: .github

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- markdownlint-disable -->
 # test <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-github-actions/test&utm_content="><img align="right" src="https://cloudposse.com/logo-300x69.svg" width="150" /></a>
-<a href="https://github.com/cloudposse-github-actions/screenshot/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-github-actions/test.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a>
+<a href="https://github.com/cloudposse-github-actions/test/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-github-actions/test.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://github.com/cloudposse-github-actions/test/commits"><img src="https://img.shields.io/github/last-commit/cloudposse-github-actions/test.svg?style=for-the-badge" alt="Last Updated"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a>
 <!-- markdownlint-restore -->
-DELETE ME
+
 <!--
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -6,42 +6,36 @@
 
 # Name of this project
 name: test
-
 # Tags of this project
 tags:
   - sandbox
   - test
-
 # Logo for this project
 #logo: docs/logo.png
 
 # License of this project
 license: "APACHE2"
-
 # Canonical GitHub repo
 github_repo: cloudposse-github-actions/test
-
 # Badges to display
 badges:
-  - name: "Latest Release"
-    image: "https://img.shields.io/github/release/cloudposse-github-actions/test.svg?style=for-the-badge"
-    url: "https://github.com/cloudposse-github-actions/screenshot/releases/latest"
-  - name: "Slack Community"
-    image: "https://slack.cloudposse.com/for-the-badge.svg"
-    url: "https://slack.cloudposse.com"
-
+  - name: Latest Release
+    image: https://img.shields.io/github/release/cloudposse-github-actions/test.svg?style=for-the-badge
+    url: https://github.com/cloudposse-github-actions/test/releases/latest
+  - name: Last Updated
+    image: https://img.shields.io/github/last-commit/cloudposse-github-actions/test.svg?style=for-the-badge
+    url: https://github.com/cloudposse-github-actions/test/commits
+  - name: Slack Community
+    image: https://slack.cloudposse.com/for-the-badge.svg
+    url: https://slack.cloudposse.com
 related: []
-
 # Short description of this project
 description: This is a test sandbox. Do not use for anything else.
-
 introduction: |-
   We use this sandbox for testing new features and ideas. It's not intended for general use.
-
 references:
   - name: "Cloud Posse GitHub Actions"
     description: "A collection of all Cloud Posse managed GitHub Actions"
     url: "https://docs.cloudposse.com/github-actions/"
-
 # Contributors to this project
 contributors: []


### PR DESCRIPTION
## what
- Reran `make readme` to rebuild `README.md` from `README.yaml`
- Migrate to square badges
- Add scaffolding for Settings, Renovate, Dependabot, and Mergify

## why
- Upstream template changed in the `.github` repo
- Work better with repository rulesets
- Modernize look & feel
